### PR TITLE
style: apply ruff-format across the repo

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -5,7 +5,13 @@ from flask_cors import CORS
 from .backend.gpt_process import ApiCaller
 from config import config
 from flask_swagger_ui import get_swaggerui_blueprint
-from prometheus_client import Counter, Histogram, generate_latest, CONTENT_TYPE_LATEST, REGISTRY
+from prometheus_client import (
+    Counter,
+    Histogram,
+    generate_latest,
+    CONTENT_TYPE_LATEST,
+    REGISTRY,
+)
 from pythonjsonlogger import jsonlogger
 
 
@@ -15,13 +21,15 @@ class _MetricProxy:
     This allows modules to import REQUEST_COUNT (and others) at import-time while
     deferring the actual metric creation until create_app() runs.
     """
+
     def __init__(self, key):
         self._key = key
 
     def _get(self):
         from flask import current_app
+
         try:
-            return current_app.extensions['metrics'][self._key]
+            return current_app.extensions["metrics"][self._key]
         except Exception:
             raise RuntimeError(
                 f"Metric '{self._key}' is not initialized. Call create_app() first or access via current_app.extensions['metrics']."
@@ -35,25 +43,35 @@ class _MetricProxy:
 
 
 # Expose proxy objects so other modules can import them safely before the app is created.
-REQUEST_COUNT = _MetricProxy('REQUEST_COUNT')
-REQUEST_LATENCY = _MetricProxy('REQUEST_LATENCY')
-API_CALL_DURATION = _MetricProxy('API_CALL_DURATION')
+REQUEST_COUNT = _MetricProxy("REQUEST_COUNT")
+REQUEST_LATENCY = _MetricProxy("REQUEST_LATENCY")
+API_CALL_DURATION = _MetricProxy("API_CALL_DURATION")
+
 
 def create_app(config_name=None):
     if config_name is None:
-        config_name = os.environ.get('FLASK_CONFIG') or 'default'
-    
+        config_name = os.environ.get("FLASK_CONFIG") or "default"
+
     app = Flask(__name__)
     app.config.from_object(config[config_name])
     config[config_name].init_app(app)
-    
+
     # Configure CORS to allow all origins
-    CORS(app, resources={r"/*": {"origins": "*", "methods": ["POST", "GET", "OPTIONS"], "allow_headers": ["Content-Type"]}})
-    
+    CORS(
+        app,
+        resources={
+            r"/*": {
+                "origins": "*",
+                "methods": ["POST", "GET", "OPTIONS"],
+                "allow_headers": ["Content-Type"],
+            }
+        },
+    )
+
     # Logging Setup
     logger = logging.getLogger()
     logger.setLevel(logging.INFO)
-    werkzeug_logger = logging.getLogger('werkzeug')
+    werkzeug_logger = logging.getLogger("werkzeug")
     werkzeug_logger.setLevel(logging.INFO)
 
     class MetricsFilter(logging.Filter):
@@ -61,13 +79,13 @@ def create_app(config_name=None):
             if record.name == "werkzeug":
                 return "/metrics" not in record.getMessage()
             try:
-                return not request.path.startswith('/metrics')
+                return not request.path.startswith("/metrics")
             except RuntimeError:
                 return True
 
     metrics_filter = MetricsFilter()
 
-    if app.config.get('TESTING'):
+    if app.config.get("TESTING"):
         # During tests on Windows, stdout/stderr can be invalid handles.
         # Use NullHandler to avoid noisy OSErrors from logging.
         logger.handlers = []
@@ -79,8 +97,8 @@ def create_app(config_name=None):
         console_handler = logging.StreamHandler()
         console_handler.addFilter(metrics_filter)
         console_formatter = jsonlogger.JsonFormatter(
-            '%(asctime)s %(levelname)s %(name)s %(message)s',
-            datefmt='%Y-%m-%d %H:%M:%S'
+            "%(asctime)s %(levelname)s %(name)s %(message)s",
+            datefmt="%Y-%m-%d %H:%M:%S",
         )
         console_handler.setFormatter(console_formatter)
         logger.addHandler(console_handler)
@@ -88,7 +106,7 @@ def create_app(config_name=None):
 
     @app.before_request
     def suppress_metrics_logging():
-        if request.path == '/metrics':
+        if request.path == "/metrics":
             app.logger.disabled = True
 
     @app.after_request
@@ -97,11 +115,12 @@ def create_app(config_name=None):
         return response
 
     from app.api import api_bp
-    app.register_blueprint(api_bp, url_prefix='')
+
+    app.register_blueprint(api_bp, url_prefix="")
 
     # Swagger UI
-    SWAGGER_URL = '/swagger'
-    API_URL = '/api/swagger.yaml'
+    SWAGGER_URL = "/swagger"
+    API_URL = "/api/swagger.yaml"
     swaggerui_blueprint = get_swaggerui_blueprint(SWAGGER_URL, API_URL)
     app.register_blueprint(swaggerui_blueprint, url_prefix=SWAGGER_URL)
 
@@ -114,11 +133,23 @@ def create_app(config_name=None):
         return constructor(name, *args, **kwargs)
 
     metrics = {
-        'REQUEST_COUNT': _get_or_create('http_requests_total', Counter, 'Total HTTP requests', ['method', 'endpoint', 'status']),
-        'REQUEST_LATENCY': _get_or_create('http_request_duration_seconds', Histogram, 'HTTP request latency', ['method', 'endpoint']),
-        'API_CALL_DURATION': _get_or_create('api_call_duration_seconds', Histogram, 'API call processing duration')
+        "REQUEST_COUNT": _get_or_create(
+            "http_requests_total",
+            Counter,
+            "Total HTTP requests",
+            ["method", "endpoint", "status"],
+        ),
+        "REQUEST_LATENCY": _get_or_create(
+            "http_request_duration_seconds",
+            Histogram,
+            "HTTP request latency",
+            ["method", "endpoint"],
+        ),
+        "API_CALL_DURATION": _get_or_create(
+            "api_call_duration_seconds", Histogram, "API call processing duration"
+        ),
     }
-    app.extensions = getattr(app, 'extensions', {})
-    app.extensions['metrics'] = metrics
+    app.extensions = getattr(app, "extensions", {})
+    app.extensions["metrics"] = metrics
 
     return app

--- a/app/api/__init__.py
+++ b/app/api/__init__.py
@@ -3,7 +3,7 @@ import logging
 
 logger = logging.getLogger(__name__)
 
-api_bp = Blueprint('api', __name__)
+api_bp = Blueprint("api", __name__)
 logger.debug("API blueprint initialized", extra={"blueprint": "api"})
 
 from app.api import routes

--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -8,36 +8,51 @@ from app.backend.handlecall import HandleCall
 # Module-level logger for routes
 logger = logging.getLogger(__name__)
 
-@api_bp.route('/example')
+
+@api_bp.route("/example")
 def example_route():
     logger.debug("Example route accessed")
     return "This is an example route"
 
-@api_bp.route('/api/swagger.yaml')
+
+@api_bp.route("/api/swagger.yaml")
 def serve_swagger_yaml():
     logger.debug("Swagger YAML requested")
-    return send_from_directory(os.path.dirname(__file__), 'swagger.yaml')
+    return send_from_directory(os.path.dirname(__file__), "swagger.yaml")
 
-@api_bp.route('/metrics')
+
+@api_bp.route("/metrics")
 def metrics():
     # Don't log metrics endpoint to avoid noise in logs
-    return generate_latest(), 200, {'Content-Type': CONTENT_TYPE_LATEST}
+    return generate_latest(), 200, {"Content-Type": CONTENT_TYPE_LATEST}
 
-@api_bp.route('/test_connection', methods=['GET'])
+
+@api_bp.route("/test_connection", methods=["GET"])
 def test():
     start_time = time.time()
     try:
-        logger.info("Test connection endpoint called", extra={"client_ip": request.remote_addr})
-        REQUEST_COUNT.labels(method='GET', endpoint='/test_connection', status='200').inc()
+        logger.info(
+            "Test connection endpoint called", extra={"client_ip": request.remote_addr}
+        )
+        REQUEST_COUNT.labels(
+            method="GET", endpoint="/test_connection", status="200"
+        ).inc()
         return jsonify("Successful"), 200
     except Exception as e:
         logger.error("Test connection failed", extra={"error": str(e)}, exc_info=True)
-        REQUEST_COUNT.labels(method='GET', endpoint='/test_connection', status='500').inc()
+        REQUEST_COUNT.labels(
+            method="GET", endpoint="/test_connection", status="500"
+        ).inc()
         return jsonify({"error": str(e)}), 500
     finally:
         duration = time.time() - start_time
-        REQUEST_LATENCY.labels(method='GET', endpoint='/test_connection').observe(duration)
-        logger.debug("Test connection completed", extra={"duration_seconds": round(duration, 4)})
+        REQUEST_LATENCY.labels(method="GET", endpoint="/test_connection").observe(
+            duration
+        )
+        logger.debug(
+            "Test connection completed", extra={"duration_seconds": round(duration, 4)}
+        )
+
 
 @api_bp.route("/api_call", methods=["POST"])
 def api_call():
@@ -48,35 +63,47 @@ def api_call():
             extra={
                 "client_ip": request.remote_addr,
                 "content_type": request.headers.get("Content-Type"),
-                "user_agent": request.headers.get("User-Agent")
-            }
+                "user_agent": request.headers.get("User-Agent"),
+            },
         )
         # Mark as deprecated via response headers per IETF recommendations
         result = HandleCall.handle(current_app, {"direction": "pnmltobpmn"})
 
         response = make_response(result)
         # Deprecation signaling headers
-        response.headers.setdefault('Deprecation', 'true')  # boolean-style flag
+        response.headers.setdefault("Deprecation", "true")  # boolean-style flag
         # Optional: set a sunset date (RFC 8594) when the endpoint will be removed
-        response.headers.setdefault('Sunset', 'Wed, 31 Dec 2025 23:59:59 GMT')
+        response.headers.setdefault("Sunset", "Wed, 31 Dec 2025 23:59:59 GMT")
         # Optional: link to deprecation/migration docs
-        response.headers.setdefault('Link', '<https://woped.dhbw-karlsruhe.de/docs/migration>; rel="deprecation"')
+        response.headers.setdefault(
+            "Link",
+            '<https://woped.dhbw-karlsruhe.de/docs/migration>; rel="deprecation"',
+        )
 
-        status_code = getattr(response, 'status_code', 200)
-        REQUEST_COUNT.labels(method='POST', endpoint='/api_call', status=str(status_code)).inc()
-        logger.info("API call completed", extra={"status": status_code, "deprecated": True})
+        status_code = getattr(response, "status_code", 200)
+        REQUEST_COUNT.labels(
+            method="POST", endpoint="/api_call", status=str(status_code)
+        ).inc()
+        logger.info(
+            "API call completed", extra={"status": status_code, "deprecated": True}
+        )
         return response
     except Exception as e:
         logger.error("API call failed", extra={"error": str(e)}, exc_info=True)
-        REQUEST_COUNT.labels(method='POST', endpoint='/api_call', status='500').inc()
+        REQUEST_COUNT.labels(method="POST", endpoint="/api_call", status="500").inc()
         return jsonify({"error": str(e)}), 500
     finally:
         duration = time.time() - start_time
-        REQUEST_LATENCY.labels(method='POST', endpoint='/api_call').observe(duration)
-        logger.debug("API call duration", extra={"duration_seconds": round(duration, 4)})
+        REQUEST_LATENCY.labels(method="POST", endpoint="/api_call").observe(duration)
+        logger.debug(
+            "API call duration", extra={"duration_seconds": round(duration, 4)}
+        )
+
 
 @api_bp.route("/generate_bpmn", methods=["POST"])  # preferred lowercase alias
-@api_bp.route("/generate_BPMN", methods=["POST"])  # legacy/case-variant for compatibility
+@api_bp.route(
+    "/generate_BPMN", methods=["POST"]
+)  # legacy/case-variant for compatibility
 def generateBPMN():
     start_time = time.time()
     endpoint_label = request.path
@@ -86,28 +113,40 @@ def generateBPMN():
             extra={
                 "endpoint": endpoint_label,
                 "client_ip": request.remote_addr,
-                "content_type": request.headers.get("Content-Type")
-            }
+                "content_type": request.headers.get("Content-Type"),
+            },
         )
-        RESPONSE_STATUS = '200'
+        RESPONSE_STATUS = "200"
         result = HandleCall.handle(current_app, {"direction": "pnmltobpmn"})
         # If HandleCall returns a tuple (response, status), reflect status in metrics
         if isinstance(result, tuple) and len(result) > 1:
             RESPONSE_STATUS = str(result[1])
-        REQUEST_COUNT.labels(method='POST', endpoint=endpoint_label, status=RESPONSE_STATUS).inc()
+        REQUEST_COUNT.labels(
+            method="POST", endpoint=endpoint_label, status=RESPONSE_STATUS
+        ).inc()
         logger.info("Generate BPMN completed", extra={"status": RESPONSE_STATUS})
         return result
     except Exception as e:
-        logger.error("Generate BPMN failed", extra={"error": str(e), "endpoint": endpoint_label}, exc_info=True)
-        REQUEST_COUNT.labels(method='POST', endpoint=endpoint_label, status='500').inc()
+        logger.error(
+            "Generate BPMN failed",
+            extra={"error": str(e), "endpoint": endpoint_label},
+            exc_info=True,
+        )
+        REQUEST_COUNT.labels(method="POST", endpoint=endpoint_label, status="500").inc()
         return jsonify({"error": str(e)}), 500
     finally:
         duration = time.time() - start_time
-        REQUEST_LATENCY.labels(method='POST', endpoint=endpoint_label).observe(duration)
-        logger.debug("Generate BPMN duration", extra={"duration_seconds": round(duration, 4), "endpoint": endpoint_label})
+        REQUEST_LATENCY.labels(method="POST", endpoint=endpoint_label).observe(duration)
+        logger.debug(
+            "Generate BPMN duration",
+            extra={"duration_seconds": round(duration, 4), "endpoint": endpoint_label},
+        )
+
 
 @api_bp.route("/generate_pnml", methods=["POST"])  # preferred lowercase alias
-@api_bp.route("/generate_PNML", methods=["POST"])  # legacy/case-variant for compatibility
+@api_bp.route(
+    "/generate_PNML", methods=["POST"]
+)  # legacy/case-variant for compatibility
 def generatePNML():
     start_time = time.time()
     endpoint_label = request.path
@@ -117,34 +156,43 @@ def generatePNML():
             extra={
                 "endpoint": endpoint_label,
                 "client_ip": request.remote_addr,
-                "content_type": request.headers.get("Content-Type")
-            }
+                "content_type": request.headers.get("Content-Type"),
+            },
         )
         result = HandleCall.handle(current_app, {"direction": "bpmntopnml"})
-        RESPONSE_STATUS = '200'
+        RESPONSE_STATUS = "200"
         if isinstance(result, tuple) and len(result) > 1:
             RESPONSE_STATUS = str(result[1])
-        REQUEST_COUNT.labels(method='POST', endpoint=endpoint_label, status=RESPONSE_STATUS).inc()
+        REQUEST_COUNT.labels(
+            method="POST", endpoint=endpoint_label, status=RESPONSE_STATUS
+        ).inc()
         logger.info("Generate PNML completed", extra={"status": RESPONSE_STATUS})
         return result
     except Exception as e:
-        logger.error("Generate PNML failed", extra={"error": str(e), "endpoint": endpoint_label}, exc_info=True)
-        REQUEST_COUNT.labels(method='POST', endpoint=endpoint_label, status='500').inc()
+        logger.error(
+            "Generate PNML failed",
+            extra={"error": str(e), "endpoint": endpoint_label},
+            exc_info=True,
+        )
+        REQUEST_COUNT.labels(method="POST", endpoint=endpoint_label, status="500").inc()
         return jsonify({"error": str(e)}), 500
     finally:
         duration = time.time() - start_time
-        REQUEST_LATENCY.labels(method='POST', endpoint=endpoint_label).observe(duration)
-        logger.debug("Generate PNML duration", extra={"duration_seconds": round(duration, 4), "endpoint": endpoint_label})
+        REQUEST_LATENCY.labels(method="POST", endpoint=endpoint_label).observe(duration)
+        logger.debug(
+            "Generate PNML duration",
+            extra={"duration_seconds": round(duration, 4), "endpoint": endpoint_label},
+        )
+
 
 @api_bp.route("/_/_/echo")
 def echo():
     start_time = time.time()
     try:
         logger.debug("Echo endpoint called", extra={"client_ip": request.remote_addr})
-        REQUEST_COUNT.labels(method='GET', endpoint='/_/_/echo', status='200').inc()
+        REQUEST_COUNT.labels(method="GET", endpoint="/_/_/echo", status="200").inc()
         return jsonify(success=True)
     finally:
         duration = time.time() - start_time
-        REQUEST_LATENCY.labels(method='GET', endpoint='/_/_/echo').observe(duration)
+        REQUEST_LATENCY.labels(method="GET", endpoint="/_/_/echo").observe(duration)
         logger.debug("Echo completed", extra={"duration_seconds": round(duration, 4)})
-

--- a/app/backend/__init__.py
+++ b/app/backend/__init__.py
@@ -2,4 +2,3 @@ import logging
 
 logger = logging.getLogger(__name__)
 logger.debug("Backend package initialized")
-

--- a/app/backend/gpt_process.py
+++ b/app/backend/gpt_process.py
@@ -169,7 +169,7 @@ class ApiCaller:
                     "xml_length": len(xml_data) if isinstance(xml_data, str) else None,
                 },
             )
-            
+
             return xml_data
         except Exception as e:
             logger.exception("Error in conversion pipeline")

--- a/app/backend/handlecall.py
+++ b/app/backend/handlecall.py
@@ -21,7 +21,9 @@ class HandleCall:
             "HandleCall.handle invoked",
             extra={
                 "endpoint": request.path if request else None,
-                "direction": directionParams.get("direction") if directionParams else None,
+                "direction": directionParams.get("direction")
+                if directionParams
+                else None,
             },
         )
         try:
@@ -71,7 +73,9 @@ class HandleCall:
             HandleCall.logger.info(
                 "conversion_pipeline completed",
                 extra={
-                    "bpmn_length": len(result_bpmn) if isinstance(result_bpmn, str) else None
+                    "bpmn_length": len(result_bpmn)
+                    if isinstance(result_bpmn, str)
+                    else None
                 },
             )
             if directionParams.get("direction") == "pnmltobpmn":
@@ -87,7 +91,9 @@ class HandleCall:
             HandleCall.logger.info(
                 "Transformation completed",
                 extra={
-                    "pnml_length": len(transformed_xml) if isinstance(transformed_xml, str) else None
+                    "pnml_length": len(transformed_xml)
+                    if isinstance(transformed_xml, str)
+                    else None
                 },
             )
             HandleCall.logger.debug(
@@ -116,10 +122,14 @@ class HandleCall:
             try:
                 service_response = e_http.response.json()
             except Exception:
-                service_response = getattr(e_http.response, "text", str(e_http.response))
+                service_response = getattr(
+                    e_http.response, "text", str(e_http.response)
+                )
 
             # Coerce non-serializable objects to string for safety
-            if not isinstance(service_response, (dict, list, str, int, float, bool, type(None))):
+            if not isinstance(
+                service_response, (dict, list, str, int, float, bool, type(None))
+            ):
                 service_response = str(service_response)
             error_payload["details"]["service_response"] = service_response
 
@@ -134,7 +144,9 @@ class HandleCall:
             app.logger.error(
                 f"Transformation service RequestException in /api_call: {str(e_req)}"
             )
-            HandleCall.logger.exception("RequestException contacting transformer service")
+            HandleCall.logger.exception(
+                "RequestException contacting transformer service"
+            )
             return (
                 jsonify(
                     {

--- a/app/backend/modeltransformer.py
+++ b/app/backend/modeltransformer.py
@@ -11,8 +11,13 @@ logger = logging.getLogger(__name__)
 
 class ModelTransformer:
     def __init__(self):
-        self.transformer_url = current_app.config['T2P_TRANSFORMER_BASE_URL'] + "/transform"
-        logger.debug("ModelTransformer initialized", extra={"transformer_url": self.transformer_url})
+        self.transformer_url = (
+            current_app.config["T2P_TRANSFORMER_BASE_URL"] + "/transform"
+        )
+        logger.debug(
+            "ModelTransformer initialized",
+            extra={"transformer_url": self.transformer_url},
+        )
 
     def transform(self, bpmn_xml, directionParams=None):
         """
@@ -26,11 +31,13 @@ class ModelTransformer:
         logger.info(
             "Starting transformation",
             extra={
-                "direction": directionParams.get("direction") if directionParams else None,
-                "bpmn_xml_length": len(bpmn_xml) if isinstance(bpmn_xml, str) else None
-            }
+                "direction": directionParams.get("direction")
+                if directionParams
+                else None,
+                "bpmn_xml_length": len(bpmn_xml) if isinstance(bpmn_xml, str) else None,
+            },
         )
-        
+
         query_params = directionParams
 
         try:
@@ -39,34 +46,34 @@ class ModelTransformer:
                 extra={
                     "url": self.transformer_url,
                     "params": query_params,
-                    "timeout": 60
-                }
+                    "timeout": 60,
+                },
             )
-            
+
             # Read the bpmn_output.xml file as a string
-            with open('bpmn_output.xml', 'r', encoding='utf-8') as f:
+            with open("bpmn_output.xml", "r", encoding="utf-8") as f:
                 bpmn_content = f.read()
                 logger.debug(
                     "Reading bpmn_output.xml file as string",
                     extra={
                         "filename": "bpmn_output.xml",
-                        "content_length": len(bpmn_content)
-                    }
+                        "content_length": len(bpmn_content),
+                    },
                 )
-            
+
             # Send the BPMN content as x-www-form-urlencoded
             form_data = {"bpmn": bpmn_content}
             headers = {"Content-Type": "application/x-www-form-urlencoded"}
-            
+
             logger.debug(
                 "Sending data as x-www-form-urlencoded",
                 extra={
                     "field_name": "bpmn",
                     "content_type": "application/x-www-form-urlencoded",
-                    "data_length": len(bpmn_content)
-                }
+                    "data_length": len(bpmn_content),
+                },
             )
-            
+
             response = requests.post(
                 self.transformer_url,
                 params=query_params,
@@ -75,14 +82,11 @@ class ModelTransformer:
                 timeout=60,  # Set a reasonable timeout (e.g., 60 seconds)
                 verify=False,  # Disable SSL certificate verification
             )
-            
+
             duration = round(time.time() - start_time, 4)
             logger.info(
                 "Transformation service responded",
-                extra={
-                    "status": response.status_code,
-                    "duration_seconds": duration
-                }
+                extra={"status": response.status_code, "duration_seconds": duration},
             )
 
             # Raise an HTTPError for bad responses (4xx or 5xx)
@@ -91,15 +95,24 @@ class ModelTransformer:
             # If successful, the response content is the transformed XML
             response_json = json.loads(response.text)
             pnml_output = response_json["pnml"]
-            
+
             logger.info(
                 "Transformation completed successfully",
                 extra={
-                    "pnml_length": len(pnml_output) if isinstance(pnml_output, str) else None,
-                    "total_duration_seconds": round(time.time() - start_time, 4)
-                }
+                    "pnml_length": len(pnml_output)
+                    if isinstance(pnml_output, str)
+                    else None,
+                    "total_duration_seconds": round(time.time() - start_time, 4),
+                },
             )
-            logger.debug("PNML output preview", extra={"pnml_preview": pnml_output[:200] if isinstance(pnml_output, str) else None})
+            logger.debug(
+                "PNML output preview",
+                extra={
+                    "pnml_preview": pnml_output[:200]
+                    if isinstance(pnml_output, str)
+                    else None
+                },
+            )
             return pnml_output
 
         except FileNotFoundError as e_file:
@@ -109,8 +122,8 @@ class ModelTransformer:
                 f"BPMN output file not found: {str(e_file)}",
                 extra={
                     "duration_seconds": duration,
-                    "error_type": type(e_file).__name__
-                }
+                    "error_type": type(e_file).__name__,
+                },
             )
             logger.exception("FileNotFoundError during transformation")
             raise
@@ -124,8 +137,10 @@ class ModelTransformer:
                     "status_code": e_http.response.status_code,
                     "url": e_http.request.url,
                     "duration_seconds": duration,
-                    "response_preview": e_http.response.text[:500] if e_http.response.text else None
-                }
+                    "response_preview": e_http.response.text[:500]
+                    if e_http.response.text
+                    else None,
+                },
             )
             logger.exception("HTTPError during transformation")
             # Re-raise the exception to be handled by the caller (app.py)
@@ -138,8 +153,8 @@ class ModelTransformer:
                 extra={
                     "url": self.transformer_url,
                     "duration_seconds": duration,
-                    "error_type": type(e_req).__name__
-                }
+                    "error_type": type(e_req).__name__,
+                },
             )
             logger.exception("RequestException during transformation")
             # Re-raise the exception to be handled by the caller (app.py)

--- a/app/backend/xml_parser.py
+++ b/app/backend/xml_parser.py
@@ -3,77 +3,147 @@ import logging
 
 logger = logging.getLogger(__name__)
 
+
 def json_to_bpmn(bpmn_data):
     logger.info(
         "Converting BPMN JSON to XML",
         extra={
-            "events": len(bpmn_data.get('events', [])) if isinstance(bpmn_data, dict) else None,
-            "tasks": len(bpmn_data.get('tasks', [])) if isinstance(bpmn_data, dict) else None,
-            "gateways": len(bpmn_data.get('gateways', [])) if isinstance(bpmn_data, dict) else None,
-            "flows": len(bpmn_data.get('flows', [])) if isinstance(bpmn_data, dict) else None,
+            "events": len(bpmn_data.get("events", []))
+            if isinstance(bpmn_data, dict)
+            else None,
+            "tasks": len(bpmn_data.get("tasks", []))
+            if isinstance(bpmn_data, dict)
+            else None,
+            "gateways": len(bpmn_data.get("gateways", []))
+            if isinstance(bpmn_data, dict)
+            else None,
+            "flows": len(bpmn_data.get("flows", []))
+            if isinstance(bpmn_data, dict)
+            else None,
         },
     )
     ns = {
-        'bpmn': 'http://www.omg.org/spec/BPMN/20100524/MODEL',
-        'bpmndi': 'http://www.omg.org/spec/BPMN/20100524/DI',
-        'di': 'http://www.omg.org/spec/DD/20100524/DI',
-        'dc': 'http://www.omg.org/spec/DD/20100524/DC',
-        'xsi': "http://www.w3.org/2001/XMLSchema-instance"
+        "bpmn": "http://www.omg.org/spec/BPMN/20100524/MODEL",
+        "bpmndi": "http://www.omg.org/spec/BPMN/20100524/DI",
+        "di": "http://www.omg.org/spec/DD/20100524/DI",
+        "dc": "http://www.omg.org/spec/DD/20100524/DC",
+        "xsi": "http://www.w3.org/2001/XMLSchema-instance",
     }
-    ET.register_namespace('', ns['bpmn'])
-    ET.register_namespace('bpmndi', ns['bpmndi'])
-    ET.register_namespace('di', ns['di'])
-    ET.register_namespace('dc', ns['dc'])
-    ET.register_namespace('xsi', ns['xsi'])
+    ET.register_namespace("", ns["bpmn"])
+    ET.register_namespace("bpmndi", ns["bpmndi"])
+    ET.register_namespace("di", ns["di"])
+    ET.register_namespace("dc", ns["dc"])
+    ET.register_namespace("xsi", ns["xsi"])
 
-    definitions = ET.Element(f"{{{ns['bpmn']}}}definitions", attrib={
-        f"{{{ns['xsi']}}}schemaLocation": "http://www.omg.org/spec/BPMN/20100524/MODEL https://www.omg.org/spec/BPMN/20100501/BPMN20.xsd",
-        'targetNamespace': "http://example.bpmn.com/schema/bpmn"
-    })
+    definitions = ET.Element(
+        f"{{{ns['bpmn']}}}definitions",
+        attrib={
+            f"{{{ns['xsi']}}}schemaLocation": "http://www.omg.org/spec/BPMN/20100524/MODEL https://www.omg.org/spec/BPMN/20100501/BPMN20.xsd",
+            "targetNamespace": "http://example.bpmn.com/schema/bpmn",
+        },
+    )
 
-    process = ET.SubElement(definitions, f"{{{ns['bpmn']}}}process", attrib={'id': 'Process_1', 'isExecutable': 'false'})
+    process = ET.SubElement(
+        definitions,
+        f"{{{ns['bpmn']}}}process",
+        attrib={"id": "Process_1", "isExecutable": "false"},
+    )
 
     # Create all events, tasks, and gateways
-    for event in bpmn_data['events']:
-        event_type = 'startEvent' if event['type'] == 'Start' else 'endEvent' if event['type'] == 'End' else 'intermediateCatchEvent'
-        ET.SubElement(process, f"{{{ns['bpmn']}}}{event_type}", id=event['id'], name=event['name'])
+    for event in bpmn_data["events"]:
+        event_type = (
+            "startEvent"
+            if event["type"] == "Start"
+            else "endEvent"
+            if event["type"] == "End"
+            else "intermediateCatchEvent"
+        )
+        ET.SubElement(
+            process, f"{{{ns['bpmn']}}}{event_type}", id=event["id"], name=event["name"]
+        )
 
-    for task in bpmn_data['tasks']:
+    for task in bpmn_data["tasks"]:
         # Convert task type to camelCase (e.g., UserTask -> userTask)
-        task_type = task['type'][0].lower() + task['type'][1:] if task['type'] else task['type']
-        ET.SubElement(process, f"{{{ns['bpmn']}}}{task_type}", id=task['id'], name=task['name'])
+        task_type = (
+            task["type"][0].lower() + task["type"][1:] if task["type"] else task["type"]
+        )
+        ET.SubElement(
+            process, f"{{{ns['bpmn']}}}{task_type}", id=task["id"], name=task["name"]
+        )
 
-    for gateway in bpmn_data['gateways']:
+    for gateway in bpmn_data["gateways"]:
         # Convert gateway type to camelCase (e.g., ParallelGateway -> parallelGateway)
-        gateway_type = gateway['type'][0].lower() + gateway['type'][1:] if gateway['type'] else gateway['type']
-        ET.SubElement(process, f"{{{ns['bpmn']}}}{gateway_type}", id=gateway['id'], name=gateway['name'])
+        gateway_type = (
+            gateway["type"][0].lower() + gateway["type"][1:]
+            if gateway["type"]
+            else gateway["type"]
+        )
+        ET.SubElement(
+            process,
+            f"{{{ns['bpmn']}}}{gateway_type}",
+            id=gateway["id"],
+            name=gateway["name"],
+        )
 
-    for flow in bpmn_data['flows']:
-        ET.SubElement(process, f"{{{ns['bpmn']}}}sequenceFlow", id=flow['id'], sourceRef=flow['source'], targetRef=flow['target'])
+    for flow in bpmn_data["flows"]:
+        ET.SubElement(
+            process,
+            f"{{{ns['bpmn']}}}sequenceFlow",
+            id=flow["id"],
+            sourceRef=flow["source"],
+            targetRef=flow["target"],
+        )
 
     # BPMNDI section
-    bpmn_di = ET.SubElement(definitions, f"{{{ns['bpmndi']}}}BPMNDiagram", attrib={'id': 'BPMNDiagram_1'})
-    bpmn_plane = ET.SubElement(bpmn_di, f"{{{ns['bpmndi']}}}BPMNPlane", attrib={'id': 'BPMNPlane_1', 'bpmnElement': 'Process_1'})
+    bpmn_di = ET.SubElement(
+        definitions, f"{{{ns['bpmndi']}}}BPMNDiagram", attrib={"id": "BPMNDiagram_1"}
+    )
+    bpmn_plane = ET.SubElement(
+        bpmn_di,
+        f"{{{ns['bpmndi']}}}BPMNPlane",
+        attrib={"id": "BPMNPlane_1", "bpmnElement": "Process_1"},
+    )
 
     # Generate diagram elements for tasks, events, gateways
-    for element in bpmn_data['tasks'] + bpmn_data['events'] + bpmn_data['gateways']:
-        bpmn_shape = ET.SubElement(bpmn_plane, f"{{{ns['bpmndi']}}}BPMNShape", attrib={'id': f"{element['id']}_di", 'bpmnElement': element['id']})
-        ET.SubElement(bpmn_shape, f"{{{ns['dc']}}}Bounds", attrib={'x': '100', 'y': '100', 'width': '100', 'height': '80'})
+    for element in bpmn_data["tasks"] + bpmn_data["events"] + bpmn_data["gateways"]:
+        bpmn_shape = ET.SubElement(
+            bpmn_plane,
+            f"{{{ns['bpmndi']}}}BPMNShape",
+            attrib={"id": f"{element['id']}_di", "bpmnElement": element["id"]},
+        )
+        ET.SubElement(
+            bpmn_shape,
+            f"{{{ns['dc']}}}Bounds",
+            attrib={"x": "100", "y": "100", "width": "100", "height": "80"},
+        )
 
     # Generate diagram elements for flows
-    for flow in bpmn_data['flows']:
-        bpmn_edge = ET.SubElement(bpmn_plane, f"{{{ns['bpmndi']}}}BPMNEdge", attrib={'id': f"{flow['id']}_di", 'bpmnElement': flow['id']})
-        waypoints = [{'x': '120', 'y': '150'}, {'x': '250', 'y': '150'}]  # Example waypoints, adjust based on actual positions
+    for flow in bpmn_data["flows"]:
+        bpmn_edge = ET.SubElement(
+            bpmn_plane,
+            f"{{{ns['bpmndi']}}}BPMNEdge",
+            attrib={"id": f"{flow['id']}_di", "bpmnElement": flow["id"]},
+        )
+        waypoints = [
+            {"x": "120", "y": "150"},
+            {"x": "250", "y": "150"},
+        ]  # Example waypoints, adjust based on actual positions
         for waypoint in waypoints:
-            ET.SubElement(bpmn_edge, f"{{{ns['di']}}}waypoint", attrib={'x': waypoint['x'], 'y': waypoint['y']})
-    
+            ET.SubElement(
+                bpmn_edge,
+                f"{{{ns['di']}}}waypoint",
+                attrib={"x": waypoint["x"], "y": waypoint["y"]},
+            )
+
     logger.debug("BPMN XML generation complete")
 
     # Save the XML to a file
     tree = ET.ElementTree(definitions)
     ET.indent(tree, space="  ", level=0)
-    tree.write('bpmn_output.xml', encoding='utf-8', xml_declaration=True)
+    tree.write("bpmn_output.xml", encoding="utf-8", xml_declaration=True)
 
-    bpmn_string = ET.tostring(definitions, encoding='utf-8', xml_declaration=True).decode('utf-8')
-    
+    bpmn_string = ET.tostring(
+        definitions, encoding="utf-8", xml_declaration=True
+    ).decode("utf-8")
+
     return bpmn_string

--- a/config.py
+++ b/config.py
@@ -1,24 +1,34 @@
 import os
+
 basedir = os.path.abspath(os.path.dirname(__file__))
 
 
 class Config:
     # Flask core
-    SECRET_KEY = os.environ.get('SECRET_KEY') or 'hard to guess string'
-    
+    SECRET_KEY = os.environ.get("SECRET_KEY") or "hard to guess string"
+
     # App-specific URLs (use T2P prefix to distinguish custom settings)
-    T2P_TRANSFORMER_BASE_URL = os.environ.get('TRANSFORMER_BASE_URL') or 'https://woped.dhbw-karlsruhe.de/pnml-bpmn-transformer'
-    T2P_LLM_API_CONNECTOR_URL = os.environ.get('LLM_API_CONNECTOR_URL') or 'https://woped.dhbw-karlsruhe.de/llm-api-connector'
-    
+    T2P_TRANSFORMER_BASE_URL = (
+        os.environ.get("TRANSFORMER_BASE_URL")
+        or "https://woped.dhbw-karlsruhe.de/pnml-bpmn-transformer"
+    )
+    T2P_LLM_API_CONNECTOR_URL = (
+        os.environ.get("LLM_API_CONNECTOR_URL")
+        or "https://woped.dhbw-karlsruhe.de/llm-api-connector"
+    )
+
     # Server configuration
-    T2P_FLASK_PORT = int(os.environ.get('FLASK_PORT') or 5000)
-    T2P_FLASK_HOST = os.environ.get('FLASK_HOST') or '127.0.0.1'
-    
+    T2P_FLASK_PORT = int(os.environ.get("FLASK_PORT") or 5000)
+    T2P_FLASK_HOST = os.environ.get("FLASK_HOST") or "127.0.0.1"
+
     # Security
     SSL_REDIRECT = False
-    WTF_CSRF_ENABLED = os.environ.get('WTF_CSRF_ENABLED', 'False').lower() in ['true', '1', 'yes']
-    
-    
+    WTF_CSRF_ENABLED = os.environ.get("WTF_CSRF_ENABLED", "False").lower() in [
+        "true",
+        "1",
+        "yes",
+    ]
+
     @staticmethod
     def init_app(app):
         pass
@@ -35,11 +45,11 @@ class TestingConfig(Config):
 
 class ProductionConfig(Config):
     SSL_REDIRECT = True
-    
+
     @classmethod
     def init_app(cls, app):
         Config.init_app(app)
-        
+
 
 class DockerConfig(ProductionConfig):
     @classmethod
@@ -61,12 +71,11 @@ class UnixConfig(ProductionConfig):
 
 
 config = {
-    'development': DevelopmentConfig,
-    'testing': TestingConfig,
-    'production': ProductionConfig,
-    'heroku': HerokuConfig,
-    'docker': DockerConfig,
-    'unix': UnixConfig,
-
-    'default': DevelopmentConfig
+    "development": DevelopmentConfig,
+    "testing": TestingConfig,
+    "production": ProductionConfig,
+    "heroku": HerokuConfig,
+    "docker": DockerConfig,
+    "unix": UnixConfig,
+    "default": DevelopmentConfig,
 }

--- a/flasky.py
+++ b/flasky.py
@@ -12,7 +12,7 @@ logger.debug("Flask app created in flasky.py", extra={"app_name": app.name})
 
 
 @app.cli.command("test")
-@click.option('--cov', is_flag=True, help="Zeige Testabdeckung (Coverage).")
+@click.option("--cov", is_flag=True, help="Zeige Testabdeckung (Coverage).")
 def test_command(cov):
     """Führe alle Tests im Ordner 'tests/' aus."""
     logger.info("Running test suite via CLI", extra={"coverage": bool(cov)})
@@ -22,4 +22,3 @@ def test_command(cov):
     result = pytest.main(args)
     logger.info("Test suite finished", extra={"exit_code": result})
     raise SystemExit(result)
-

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,30 +1,32 @@
 """
 Shared pytest fixtures and configuration
 """
+
 import pytest
 import os
 import sys
 from unittest.mock import Mock
 
 # Add the project root to the path
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture(scope="session")
 def app():
     """Create application for the tests."""
     from app import create_app
-    app = create_app('testing')
+
+    app = create_app("testing")
     return app
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope="function")
 def client(app):
     """Create a test client for the app."""
     return app.test_client()
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope="function")
 def runner(app):
     """Create a test runner for the app's Click commands."""
     return app.test_cli_runner()
@@ -34,21 +36,32 @@ def runner(app):
 def mock_llm_response():
     """Mock LLM API response"""
     import json
+
     return {
-        "message": json.dumps({
-            "events": [
-                {"id": "startEvent1", "type": "Start", "name": "Process Start"},
-                {"id": "endEvent1", "type": "End", "name": "Process End"}
-            ],
-            "tasks": [
-                {"id": "task1", "name": "Example Task", "type": "UserTask"}
-            ],
-            "gateways": [],
-            "flows": [
-                {"id": "flow1", "source": "startEvent1", "target": "task1", "type": "SequenceFlow"},
-                {"id": "flow2", "source": "task1", "target": "endEvent1", "type": "SequenceFlow"}
-            ]
-        })
+        "message": json.dumps(
+            {
+                "events": [
+                    {"id": "startEvent1", "type": "Start", "name": "Process Start"},
+                    {"id": "endEvent1", "type": "End", "name": "Process End"},
+                ],
+                "tasks": [{"id": "task1", "name": "Example Task", "type": "UserTask"}],
+                "gateways": [],
+                "flows": [
+                    {
+                        "id": "flow1",
+                        "source": "startEvent1",
+                        "target": "task1",
+                        "type": "SequenceFlow",
+                    },
+                    {
+                        "id": "flow2",
+                        "source": "task1",
+                        "target": "endEvent1",
+                        "type": "SequenceFlow",
+                    },
+                ],
+            }
+        )
     }
 
 
@@ -58,16 +71,24 @@ def sample_bpmn_json():
     return {
         "events": [
             {"id": "start1", "type": "Start", "name": "Start"},
-            {"id": "end1", "type": "End", "name": "End"}
+            {"id": "end1", "type": "End", "name": "End"},
         ],
-        "tasks": [
-            {"id": "task1", "name": "Task 1", "type": "UserTask"}
-        ],
+        "tasks": [{"id": "task1", "name": "Task 1", "type": "UserTask"}],
         "gateways": [],
         "flows": [
-            {"id": "flow1", "source": "start1", "target": "task1", "type": "SequenceFlow"},
-            {"id": "flow2", "source": "task1", "target": "end1", "type": "SequenceFlow"}
-        ]
+            {
+                "id": "flow1",
+                "source": "start1",
+                "target": "task1",
+                "type": "SequenceFlow",
+            },
+            {
+                "id": "flow2",
+                "source": "task1",
+                "target": "end1",
+                "type": "SequenceFlow",
+            },
+        ],
     }
 
 
@@ -92,7 +113,7 @@ def sample_bpmn_xml():
 @pytest.fixture
 def mock_transformer_response():
     """Mock transformer API response"""
-    return '<pnml><net>Transformed PNML</net></pnml>'
+    return "<pnml><net>Transformed PNML</net></pnml>"
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -3,58 +3,67 @@ import pytest
 from app import create_app
 from unittest.mock import patch
 
+
 @pytest.fixture
 def client():
-    app = create_app()  
-    app.config['TESTING'] = True
+    app = create_app()
+    app.config["TESTING"] = True
     with app.test_client() as client:
         yield client
 
 
 def test_test_connection(client):
-    response = client.get('/test_connection')
+    response = client.get("/test_connection")
     assert response.status_code == 200
     assert response.json == "Successful"
 
+
 def test_echo(client):
-    response = client.get('/_/_/echo')
+    response = client.get("/_/_/echo")
     assert response.status_code == 200
-    assert response.json['success'] is True
+    assert response.json["success"] is True
+
 
 def test_metrics(client):
-    response = client.get('/metrics')
+    response = client.get("/metrics")
     assert response.status_code == 200
-    assert b'http_requests_total' in response.data
+    assert b"http_requests_total" in response.data
+
 
 def test_api_call(client):
-    response = client.post('/api_call', json={})
+    response = client.post("/api_call", json={})
     assert response.status_code in (400, 500)
+
 
 def test_generate_BPMN_call(client):
-    response = client.post('/generate_BPMN', json={})
+    response = client.post("/generate_BPMN", json={})
     assert response.status_code in (400, 500)
+
 
 def test_generate_PNML_call(client):
-    response = client.post('/generate_PNML', json={})
+    response = client.post("/generate_PNML", json={})
     assert response.status_code in (400, 500)
 
-@patch('app.backend.handlecall.HandleCall.handle', side_effect=Exception("Simulated Crash"))
+
+@patch(
+    "app.backend.handlecall.HandleCall.handle", side_effect=Exception("Simulated Crash")
+)
 def test_api_call_exception(mock_handle, client):
-    response = client.post('/api_call', json={"text": "example", "api_key": "key"})
+    response = client.post("/api_call", json={"text": "example", "api_key": "key"})
     assert response.status_code == 500
-    assert 'error' in response.json
+    assert "error" in response.json
 
 
 def test_generate_bpmn_lowercase_route(client):
     """Test lowercase /generate_bpmn route exists"""
-    response = client.post('/generate_bpmn', json={})
+    response = client.post("/generate_bpmn", json={})
     # Should get 400 or 500, but not 404
     assert response.status_code in (400, 500)
 
 
 def test_generate_pnml_lowercase_route(client):
     """Test lowercase /generate_pnml route exists"""
-    response = client.post('/generate_pnml', json={})
+    response = client.post("/generate_pnml", json={})
     # Should get 400 or 500, but not 404
     assert response.status_code in (400, 500)
 
@@ -62,6 +71,7 @@ def test_generate_pnml_lowercase_route(client):
 def test_app_has_swagger_ui():
     """Test that Swagger UI blueprint is registered"""
     from app import create_app
+
     app = create_app()
     # Check if swagger blueprint exists
     blueprints = [bp for bp in app.blueprints.keys()]
@@ -72,29 +82,30 @@ def test_app_has_swagger_ui():
 def test_app_configuration():
     """Test app is properly configured"""
     from app import create_app
-    app = create_app('testing')
-    assert app.config['TESTING'] == True
-    assert 'T2P_TRANSFORMER_BASE_URL' in app.config
-    assert 'T2P_LLM_API_CONNECTOR_URL' in app.config
+
+    app = create_app("testing")
+    assert app.config["TESTING"] == True
+    assert "T2P_TRANSFORMER_BASE_URL" in app.config
+    assert "T2P_LLM_API_CONNECTOR_URL" in app.config
 
 
 def test_metrics_extension_registered():
     """Test that Prometheus metrics are registered"""
     from app import create_app
+
     app = create_app()
-    assert 'metrics' in app.extensions
-    assert 'REQUEST_COUNT' in app.extensions['metrics']
-    assert 'REQUEST_LATENCY' in app.extensions['metrics']
+    assert "metrics" in app.extensions
+    assert "REQUEST_COUNT" in app.extensions["metrics"]
+    assert "REQUEST_LATENCY" in app.extensions["metrics"]
 
 
 def test_logging_configured():
     """Test that logging is configured"""
     from app import create_app
     import logging
+
     app = create_app()
     # Root logger should be configured
     logger = logging.getLogger()
     assert logger.level != logging.NOTSET
     assert len(logger.handlers) > 0
-
-

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,45 +1,47 @@
 """
 Tests for configuration module
 """
+
 import os
 from config import (
-    Config, 
-    DevelopmentConfig, 
-    TestingConfig, 
-    ProductionConfig, 
+    Config,
+    DevelopmentConfig,
+    TestingConfig,
+    ProductionConfig,
     DockerConfig,
     HerokuConfig,
     UnixConfig,
-    config
+    config,
 )
 
 
 class TestBaseConfig:
     """Tests for base Config class"""
-    
+
     def test_config_has_secret_key(self):
-        assert hasattr(Config, 'SECRET_KEY')
+        assert hasattr(Config, "SECRET_KEY")
         assert Config.SECRET_KEY is not None
-    
+
     def test_config_has_transformer_url(self):
-        assert hasattr(Config, 'T2P_TRANSFORMER_BASE_URL')
+        assert hasattr(Config, "T2P_TRANSFORMER_BASE_URL")
         assert Config.T2P_TRANSFORMER_BASE_URL is not None
-    
+
     def test_config_has_llm_connector_url(self):
-        assert hasattr(Config, 'T2P_LLM_API_CONNECTOR_URL')
+        assert hasattr(Config, "T2P_LLM_API_CONNECTOR_URL")
         assert Config.T2P_LLM_API_CONNECTOR_URL is not None
-    
+
     def test_config_has_port_and_host(self):
-        assert hasattr(Config, 'T2P_FLASK_PORT')
-        assert hasattr(Config, 'T2P_FLASK_HOST')
+        assert hasattr(Config, "T2P_FLASK_PORT")
+        assert hasattr(Config, "T2P_FLASK_HOST")
         assert isinstance(Config.T2P_FLASK_PORT, int)
         assert isinstance(Config.T2P_FLASK_HOST, str)
-    
+
     def test_config_ssl_redirect_default(self):
         assert Config.SSL_REDIRECT == False
-    
+
     def test_config_init_app(self):
         from unittest.mock import Mock
+
         app = Mock()
         # Should not raise exception
         Config.init_app(app)
@@ -47,29 +49,30 @@ class TestBaseConfig:
 
 class TestDevelopmentConfig:
     """Tests for DevelopmentConfig"""
-    
+
     def test_development_debug_enabled(self):
         assert DevelopmentConfig.DEBUG == True
 
 
 class TestTestingConfig:
     """Tests for TestingConfig"""
-    
+
     def test_testing_flag_enabled(self):
         assert TestingConfig.TESTING == True
-    
+
     def test_testing_csrf_disabled(self):
         assert TestingConfig.WTF_CSRF_ENABLED == False
-    
+
 
 class TestProductionConfig:
     """Tests for ProductionConfig"""
-    
+
     def test_production_ssl_redirect_enabled(self):
         assert ProductionConfig.SSL_REDIRECT == True
-    
+
     def test_production_init_app(self):
         from unittest.mock import Mock
+
         app = Mock()
         ProductionConfig.init_app(app)
         # Should not raise exception
@@ -77,45 +80,46 @@ class TestProductionConfig:
 
 class TestDockerConfig:
     """Tests for DockerConfig"""
-    
+
     def test_docker_inherits_from_production(self):
         assert issubclass(DockerConfig, ProductionConfig)
-    
+
     def test_docker_init_app(self):
         from unittest.mock import Mock
+
         app = Mock()
         DockerConfig.init_app(app)
 
 
 class TestHerokuConfig:
     """Tests for HerokuConfig"""
-    
+
     def test_heroku_inherits_from_production(self):
         assert issubclass(HerokuConfig, ProductionConfig)
 
 
 class TestUnixConfig:
     """Tests for UnixConfig"""
-    
+
     def test_unix_inherits_from_production(self):
         assert issubclass(UnixConfig, ProductionConfig)
 
 
 class TestConfigDict:
     """Tests for config dictionary"""
-    
+
     def test_config_dict_has_all_environments(self):
-        assert 'development' in config
-        assert 'testing' in config
-        assert 'production' in config
-        assert 'docker' in config
-        assert 'heroku' in config
-        assert 'unix' in config
-        assert 'default' in config
-    
+        assert "development" in config
+        assert "testing" in config
+        assert "production" in config
+        assert "docker" in config
+        assert "heroku" in config
+        assert "unix" in config
+        assert "default" in config
+
     def test_config_default_is_development(self):
-        assert config['default'] == DevelopmentConfig
-    
+        assert config["default"] == DevelopmentConfig
+
     def test_config_values_are_classes(self):
         for key, value in config.items():
             assert isinstance(value, type)
@@ -124,27 +128,30 @@ class TestConfigDict:
 
 class TestConfigEnvironmentVariables:
     """Tests for environment variable handling"""
-    
+
     def test_secret_key_from_env(self, monkeypatch):
-        test_key = 'test-secret-key-123'
-        monkeypatch.setenv('SECRET_KEY', test_key)
+        test_key = "test-secret-key-123"
+        monkeypatch.setenv("SECRET_KEY", test_key)
         # Reload config
         from importlib import reload
         import config as config_module
+
         reload(config_module)
         assert config_module.Config.SECRET_KEY == test_key
-    
+
     def test_flask_port_from_env(self, monkeypatch):
-        monkeypatch.setenv('FLASK_PORT', '8080')
+        monkeypatch.setenv("FLASK_PORT", "8080")
         from importlib import reload
         import config as config_module
+
         reload(config_module)
         assert config_module.Config.T2P_FLASK_PORT == 8080
-    
+
     def test_flask_host_from_env(self, monkeypatch):
-        test_host = '0.0.0.0'
-        monkeypatch.setenv('FLASK_HOST', test_host)
+        test_host = "0.0.0.0"
+        monkeypatch.setenv("FLASK_HOST", test_host)
         from importlib import reload
         import config as config_module
+
         reload(config_module)
         assert config_module.Config.T2P_FLASK_HOST == test_host

--- a/tests/test_handlecall.py
+++ b/tests/test_handlecall.py
@@ -3,128 +3,127 @@ import requests
 from unittest.mock import patch
 from app import create_app
 
+
 @pytest.fixture
 def client():
-    app = create_app()  
-    app.config['TESTING'] = True
+    app = create_app()
+    app.config["TESTING"] = True
     with app.test_client() as client:
         yield client
 
+
 # ---- Test 1: Erfolgreicher Aufruf (BPMN aus Text) ----
-@patch('app.backend.handlecall.ApiCaller.conversion_pipeline')
+@patch("app.backend.handlecall.ApiCaller.conversion_pipeline")
 def test_generate_BPMN_success(mock_conversion_pipeline, client):
     mock_conversion_pipeline.return_value = "<bpmn-xml></bpmn-xml>"
 
-    response = client.post('/generate_BPMN', json={
-        'text': 'Example process',
-        'api_key': 'test_key'
-    })
+    response = client.post(
+        "/generate_BPMN", json={"text": "Example process", "api_key": "test_key"}
+    )
 
     assert response.status_code == 200
-    assert 'result' in response.json
-    assert '<bpmn-xml>' in response.json['result']
+    assert "result" in response.json
+    assert "<bpmn-xml>" in response.json["result"]
+
 
 # ---- Test 2: Fehlende Felder ----
 def test_generate_BPMN_missing_fields(client):
-    response = client.post('/generate_BPMN', json={
-        'api_key': 'test_key'
-    })
+    response = client.post("/generate_BPMN", json={"api_key": "test_key"})
     assert response.status_code == 400
-    assert 'Missing data' in response.json['error']
+    assert "Missing data" in response.json["error"]
+
 
 # ---- Test 3: Kein JSON im Body ----
 def test_generate_BPMN_no_json(client):
-    response = client.post('/generate_BPMN', data='no-json-here', content_type='text/plain')
+    response = client.post(
+        "/generate_BPMN", data="no-json-here", content_type="text/plain"
+    )
     assert response.status_code == 400
-    assert 'Request body must be JSON' in response.json['error']
+    assert "Request body must be JSON" in response.json["error"]
+
 
 # ---- Test 4: Leeres JSON ----
 def test_generate_BPMN_empty_json(client):
-    response = client.post('/generate_BPMN', json={})
+    response = client.post("/generate_BPMN", json={})
     assert response.status_code == 400
-    assert 'Request body must be JSON' in response.json['error']
+    assert "Request body must be JSON" in response.json["error"]
 
 
 # ---- Test 5: HTTPError from transformer ----
-@patch('app.backend.handlecall.ApiCaller.conversion_pipeline')
-@patch('app.backend.handlecall.ModelTransformer.transform')
+@patch("app.backend.handlecall.ApiCaller.conversion_pipeline")
+@patch("app.backend.handlecall.ModelTransformer.transform")
 def test_generate_PNML_http_error(mock_transform, mock_conversion, client):
     from requests.exceptions import HTTPError
     from unittest.mock import Mock
-    
+
     mock_conversion.return_value = "<bpmn>Test</bpmn>"
     mock_response = Mock()
     mock_response.status_code = 500
     mock_response.text = "Internal Server Error"
     mock_transform.side_effect = HTTPError(response=mock_response)
 
-    response = client.post('/generate_PNML', json={
-        'text': 'Example process',
-        'api_key': 'test_key'
-    })
+    response = client.post(
+        "/generate_PNML", json={"text": "Example process", "api_key": "test_key"}
+    )
 
     assert response.status_code == 500
-    assert 'TransformerServiceError' in response.json['details']['type']
+    assert "TransformerServiceError" in response.json["details"]["type"]
 
 
 # ---- Test 6: RequestException from transformer ----
-@patch('app.backend.handlecall.ApiCaller.conversion_pipeline')
-@patch('app.backend.handlecall.ModelTransformer.transform')
+@patch("app.backend.handlecall.ApiCaller.conversion_pipeline")
+@patch("app.backend.handlecall.ModelTransformer.transform")
 def test_generate_PNML_request_exception(mock_transform, mock_conversion, client):
     from requests.exceptions import RequestException
-    
+
     mock_conversion.return_value = "<bpmn>Test</bpmn>"
     mock_transform.side_effect = RequestException("Network error")
 
-    response = client.post('/generate_PNML', json={
-        'text': 'Example process',
-        'api_key': 'test_key'
-    })
+    response = client.post(
+        "/generate_PNML", json={"text": "Example process", "api_key": "test_key"}
+    )
 
     assert response.status_code == 500
-    assert 'NetworkError' in response.json['details']['type']
+    assert "NetworkError" in response.json["details"]["type"]
 
 
 # ---- Test 7: ValueError from LLM ----
-@patch('app.backend.handlecall.ApiCaller.conversion_pipeline')
+@patch("app.backend.handlecall.ApiCaller.conversion_pipeline")
 def test_generate_BPMN_value_error(mock_conversion, client):
     mock_conversion.side_effect = ValueError("Invalid JSON from LLM")
 
-    response = client.post('/generate_BPMN', json={
-        'text': 'Example process',
-        'api_key': 'test_key'
-    })
+    response = client.post(
+        "/generate_BPMN", json={"text": "Example process", "api_key": "test_key"}
+    )
 
     assert response.status_code == 500
-    assert 'LLMResponseError' in response.json['details']['type']
+    assert "LLMResponseError" in response.json["details"]["type"]
 
 
 # ---- Test 8: RuntimeError from LLM connector ----
-@patch('app.backend.handlecall.ApiCaller.conversion_pipeline')
+@patch("app.backend.handlecall.ApiCaller.conversion_pipeline")
 def test_generate_BPMN_runtime_error(mock_conversion, client):
     mock_conversion.side_effect = RuntimeError("LLM API connector failed")
 
-    response = client.post('/generate_BPMN', json={
-        'text': 'Example process',
-        'api_key': 'test_key'
-    })
+    response = client.post(
+        "/generate_BPMN", json={"text": "Example process", "api_key": "test_key"}
+    )
 
     assert response.status_code == 500
-    assert 'LLMConnectorError' in response.json['details']['type']
+    assert "LLMConnectorError" in response.json["details"]["type"]
 
 
 # ---- Test 9: Successful PNML generation ----
-@patch('app.backend.handlecall.ApiCaller.conversion_pipeline')
-@patch('app.backend.handlecall.ModelTransformer.transform')
+@patch("app.backend.handlecall.ApiCaller.conversion_pipeline")
+@patch("app.backend.handlecall.ModelTransformer.transform")
 def test_generate_PNML_success(mock_transform, mock_conversion, client):
     mock_conversion.return_value = "<bpmn>Test</bpmn>"
     mock_transform.return_value = "<pnml>Test-PNML</pnml>"
 
-    response = client.post('/generate_PNML', json={
-        'text': 'Example process',
-        'api_key': 'test_key'
-    })
+    response = client.post(
+        "/generate_PNML", json={"text": "Example process", "api_key": "test_key"}
+    )
 
     assert response.status_code == 200
-    assert 'result' in response.json
-    assert '<pnml>Test-PNML</pnml>' in response.json['result']
+    assert "result" in response.json
+    assert "<pnml>Test-PNML</pnml>" in response.json["result"]

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,6 +1,7 @@
 """
 Integration tests for the complete T2P workflow
 """
+
 import pytest
 from unittest.mock import patch, Mock
 import json
@@ -10,7 +11,8 @@ import json
 def app():
     """Create test Flask app"""
     from app import create_app
-    app = create_app('testing')
+
+    app = create_app("testing")
     return app
 
 
@@ -22,50 +24,63 @@ def client(app):
 
 class TestEndToEndBPMNGeneration:
     """End-to-end tests for BPMN generation workflow"""
-    
-    @patch('app.backend.gpt_process.requests.post')
+
+    @patch("app.backend.gpt_process.requests.post")
     def test_complete_bpmn_generation_flow(self, mock_llm_request, client):
         """Test complete flow from text to BPMN"""
         # Mock LLM API response
         mock_response = Mock()
         mock_response.status_code = 200
         mock_response.json.return_value = {
-            "message": json.dumps({
-                "events": [
-                    {"id": "start1", "type": "Start", "name": "Process Start"},
-                    {"id": "end1", "type": "End", "name": "Process End"}
-                ],
-                "tasks": [
-                    {"id": "task1", "name": "Do Something", "type": "UserTask"}
-                ],
-                "gateways": [],
-                "flows": [
-                    {"id": "flow1", "source": "start1", "target": "task1", "type": "SequenceFlow"},
-                    {"id": "flow2", "source": "task1", "target": "end1", "type": "SequenceFlow"}
-                ]
-            })
+            "message": json.dumps(
+                {
+                    "events": [
+                        {"id": "start1", "type": "Start", "name": "Process Start"},
+                        {"id": "end1", "type": "End", "name": "Process End"},
+                    ],
+                    "tasks": [
+                        {"id": "task1", "name": "Do Something", "type": "UserTask"}
+                    ],
+                    "gateways": [],
+                    "flows": [
+                        {
+                            "id": "flow1",
+                            "source": "start1",
+                            "target": "task1",
+                            "type": "SequenceFlow",
+                        },
+                        {
+                            "id": "flow2",
+                            "source": "task1",
+                            "target": "end1",
+                            "type": "SequenceFlow",
+                        },
+                    ],
+                }
+            )
         }
         mock_llm_request.return_value = mock_response
-        
+
         # Make request
-        response = client.post('/generate_bpmn', json={
-            'text': 'A simple process with one task',
-            'api_key': 'test_api_key'
-        })
-        
+        response = client.post(
+            "/generate_bpmn",
+            json={"text": "A simple process with one task", "api_key": "test_api_key"},
+        )
+
         # Verify response
         assert response.status_code == 200
-        assert 'result' in response.json
-        result = response.json['result']
-        assert '<?xml' in result
-        assert 'start1' in result
-        assert 'task1' in result
-        assert 'end1' in result
+        assert "result" in response.json
+        result = response.json["result"]
+        assert "<?xml" in result
+        assert "start1" in result
+        assert "task1" in result
+        assert "end1" in result
+
 
 # TODO: Mock pnml correctly
 # class TestEndToEndPNMLGeneration:
 #     """End-to-end tests for PNML generation workflow"""
-    
+
 #     @patch('app.backend.gpt_process.requests.post')
 #     @patch('app.backend.modeltransformer.requests.post')
 #     def test_complete_pnml_generation_flow(self, mock_transformer, mock_llm, client):
@@ -90,20 +105,20 @@ class TestEndToEndBPMNGeneration:
 #             })
 #         }
 #         mock_llm.return_value = mock_llm_response
-        
+
 #         # Mock transformer response
 #         mock_transformer_response = Mock()
 #         mock_transformer_response.status_code = 200
 #         mock_transformer_response.text = '<pnml>Transformed PNML</pnml>'
 #         mock_transformer_response.raise_for_status = Mock()
 #         mock_transformer.return_value = mock_transformer_response
-        
+
 #         # Make request
 #         response = client.post('/generate_pnml', json={
 #             'text': 'A simple process',
 #             'api_key': 'test_api_key'
 #         })
-        
+
 #         # Verify response
 #         assert response.status_code == 200
 #         assert 'result' in response.json
@@ -112,51 +127,46 @@ class TestEndToEndBPMNGeneration:
 
 class TestErrorHandling:
     """Tests for various error scenarios"""
-    
+
     def test_missing_api_key(self, client):
         """Test request without API key"""
-        response = client.post('/generate_bpmn', json={
-            'text': 'Some process'
-        })
-        
+        response = client.post("/generate_bpmn", json={"text": "Some process"})
+
         assert response.status_code == 400
-        assert 'error' in response.json
-        assert 'api_key' in response.json['error']
-    
+        assert "error" in response.json
+        assert "api_key" in response.json["error"]
+
     def test_missing_text(self, client):
         """Test request without text"""
-        response = client.post('/generate_bpmn', json={
-            'api_key': 'test_key'
-        })
-        
+        response = client.post("/generate_bpmn", json={"api_key": "test_key"})
+
         assert response.status_code == 400
-        assert 'error' in response.json
-        assert 'text' in response.json['error']
-    
+        assert "error" in response.json
+        assert "text" in response.json["error"]
+
     def test_empty_request_body(self, client):
         """Test request with empty body"""
-        response = client.post('/generate_bpmn', json={})
-        
+        response = client.post("/generate_bpmn", json={})
+
         assert response.status_code == 400
-        assert 'error' in response.json
-    
-    @patch('app.backend.gpt_process.requests.post')
+        assert "error" in response.json
+
+    @patch("app.backend.gpt_process.requests.post")
     def test_llm_api_error(self, mock_llm, client):
         """Test LLM API returning error"""
         mock_response = Mock()
         mock_response.status_code = 500
         mock_response.text = "Internal Server Error"
         mock_llm.return_value = mock_response
-        
-        response = client.post('/generate_bpmn', json={
-            'text': 'Some process',
-            'api_key': 'test_key'
-        })
-        
+
+        response = client.post(
+            "/generate_bpmn", json={"text": "Some process", "api_key": "test_key"}
+        )
+
         assert response.status_code == 500
-        assert 'error' in response.json
-    
-    @patch('app.backend.gpt_process.requests.post')
+        assert "error" in response.json
+
+    @patch("app.backend.gpt_process.requests.post")
     def test_invalid_json_from_llm(self, mock_llm, client):
         """Test LLM returning invalid JSON"""
         mock_response = Mock()
@@ -165,77 +175,73 @@ class TestErrorHandling:
             "message": "{'invalid': 'json with single quotes'}"
         }
         mock_llm.return_value = mock_response
-        
-        response = client.post('/generate_bpmn', json={
-            'text': 'Some process',
-            'api_key': 'test_key'
-        })
-        
+
+        response = client.post(
+            "/generate_bpmn", json={"text": "Some process", "api_key": "test_key"}
+        )
+
         assert response.status_code == 500
-        assert 'error' in response.json
-        assert 'LLMResponseError' in response.json.get('details', {}).get('type', '')
+        assert "error" in response.json
+        assert "LLMResponseError" in response.json.get("details", {}).get("type", "")
 
 
 class TestMetricsIntegration:
     """Tests for Prometheus metrics integration"""
-    
+
     def test_metrics_updated_on_request(self, client):
         """Test that metrics are updated when requests are made"""
         # Make a request
-        client.get('/test_connection')
-        
+        client.get("/test_connection")
+
         # Check metrics endpoint
-        metrics_response = client.get('/metrics')
+        metrics_response = client.get("/metrics")
         assert metrics_response.status_code == 200
-        
+
         # Metrics should contain request data
-        metrics_data = metrics_response.data.decode('utf-8')
-        assert 'http_requests_total' in metrics_data or 'REQUEST_COUNT' in metrics_data
-    
+        metrics_data = metrics_response.data.decode("utf-8")
+        assert "http_requests_total" in metrics_data or "REQUEST_COUNT" in metrics_data
+
     def test_metrics_track_different_endpoints(self, client):
         """Test that different endpoints are tracked separately"""
-        client.get('/test_connection')
-        client.get('/_/_/echo')
-        
-        metrics_response = client.get('/metrics')
-        metrics_data = metrics_response.data.decode('utf-8')
-        
+        client.get("/test_connection")
+        client.get("/_/_/echo")
+
+        metrics_response = client.get("/metrics")
+        metrics_data = metrics_response.data.decode("utf-8")
+
         # Should have metrics for both endpoints
-        assert 'test_connection' in metrics_data or '/test_connection' in metrics_data
-        assert 'echo' in metrics_data or '/_/_/echo' in metrics_data
+        assert "test_connection" in metrics_data or "/test_connection" in metrics_data
+        assert "echo" in metrics_data or "/_/_/echo" in metrics_data
 
 
 class TestDeprecationHeaders:
     """Tests for deprecation warning headers"""
-    
-    @patch('app.api.routes.HandleCall.handle')
+
+    @patch("app.api.routes.HandleCall.handle")
     def test_deprecated_endpoint_headers(self, mock_handle, client):
         """Test that deprecated endpoint includes proper headers"""
-        mock_handle.return_value = ({'result': 'test'}, 200)
-        
-        response = client.post('/api_call', json={
-            'text': 'test',
-            'api_key': 'key'
-        })
-        
+        mock_handle.return_value = ({"result": "test"}, 200)
+
+        response = client.post("/api_call", json={"text": "test", "api_key": "key"})
+
         # Check deprecation headers
-        assert 'Deprecation' in response.headers
-        assert response.headers['Deprecation'] == 'true'
-        assert 'Sunset' in response.headers
-        assert 'Link' in response.headers
-        assert 'deprecation' in response.headers['Link'].lower()
+        assert "Deprecation" in response.headers
+        assert response.headers["Deprecation"] == "true"
+        assert "Sunset" in response.headers
+        assert "Link" in response.headers
+        assert "deprecation" in response.headers["Link"].lower()
 
 
 class TestCORSAndSecurity:
     """Tests for CORS and security headers"""
-    
+
     def test_cors_headers_present(self, client):
         """Test CORS headers are configured"""
-        response = client.get('/test_connection')
+        response = client.get("/test_connection")
         # CORS headers might be configured, check if response is valid
         assert response.status_code == 200
-    
+
     def test_content_type_json(self, client):
         """Test JSON endpoints return correct content type"""
-        response = client.get('/test_connection')
-        assert 'application/json' in response.content_type
+        response = client.get("/test_connection")
+        assert "application/json" in response.content_type

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1,6 +1,7 @@
 """
 Comprehensive tests for API routes in app.api.routes
 """
+
 import pytest
 from unittest.mock import patch, Mock
 from flask import Flask
@@ -10,8 +11,9 @@ from flask import Flask
 def app():
     """Create test Flask app"""
     from app import create_app
-    app = create_app('testing')
-    app.config['TESTING'] = True
+
+    app = create_app("testing")
+    app.config["TESTING"] = True
     return app
 
 
@@ -23,35 +25,37 @@ def client(app):
 
 class TestExampleRoute:
     """Tests for /example endpoint"""
-    
+
     def test_example_route_success(self, client):
-        response = client.get('/example')
+        response = client.get("/example")
         assert response.status_code == 200
-        assert b'This is an example route' in response.data
+        assert b"This is an example route" in response.data
 
 
 class TestMetrics:
     """Tests for /metrics endpoint"""
-    
+
     def test_metrics_endpoint(self, client):
-        response = client.get('/metrics')
+        response = client.get("/metrics")
         assert response.status_code == 200
-        assert response.content_type.startswith('text/plain')
+        assert response.content_type.startswith("text/plain")
         # Prometheus metrics should contain these
-        assert b'http_requests_total' in response.data or b'REQUEST_COUNT' in response.data
+        assert (
+            b"http_requests_total" in response.data or b"REQUEST_COUNT" in response.data
+        )
 
 
 class TestConnectionEndpoint:
     """Tests for /test_connection endpoint"""
-    
+
     def test_connection_success(self, client):
-        response = client.get('/test_connection')
+        response = client.get("/test_connection")
         assert response.status_code == 200
         assert response.json == "Successful"
-    
-    @patch('app.api.routes.REQUEST_COUNT')
+
+    @patch("app.api.routes.REQUEST_COUNT")
     def test_connection_increments_counter(self, mock_counter, client):
-        response = client.get('/test_connection')
+        response = client.get("/test_connection")
         assert response.status_code == 200
         # Verify counter was incremented
         mock_counter.labels.assert_called()
@@ -59,152 +63,142 @@ class TestConnectionEndpoint:
 
 class TestDeprecatedAPICall:
     """Tests for deprecated /api_call endpoint"""
-    
-    @patch('app.api.routes.HandleCall.handle')
+
+    @patch("app.api.routes.HandleCall.handle")
     def test_api_call_returns_deprecation_headers(self, mock_handle, client):
-        mock_handle.return_value = ({'result': 'test'}, 200)
-        
-        response = client.post('/api_call', json={
-            'text': 'test process',
-            'api_key': 'test_key'
-        })
-        
+        mock_handle.return_value = ({"result": "test"}, 200)
+
+        response = client.post(
+            "/api_call", json={"text": "test process", "api_key": "test_key"}
+        )
+
         assert response.status_code == 200
-        assert 'Deprecation' in response.headers
-        assert response.headers['Deprecation'] == 'true'
-        assert 'Sunset' in response.headers
-        assert 'Link' in response.headers
-    
-    @patch('app.api.routes.HandleCall.handle')
+        assert "Deprecation" in response.headers
+        assert response.headers["Deprecation"] == "true"
+        assert "Sunset" in response.headers
+        assert "Link" in response.headers
+
+    @patch("app.api.routes.HandleCall.handle")
     def test_api_call_handles_exception(self, mock_handle, client):
         mock_handle.side_effect = Exception("Test error")
-        
-        response = client.post('/api_call', json={
-            'text': 'test process',
-            'api_key': 'test_key'
-        })
-        
+
+        response = client.post(
+            "/api_call", json={"text": "test process", "api_key": "test_key"}
+        )
+
         assert response.status_code == 500
-        assert 'error' in response.json
+        assert "error" in response.json
 
 
 class TestGenerateBPMN:
     """Tests for /generate_bpmn and /generate_BPMN endpoints"""
-    
-    @patch('app.api.routes.HandleCall.handle')
+
+    @patch("app.api.routes.HandleCall.handle")
     def test_generate_bpmn_lowercase_success(self, mock_handle, client):
-        mock_handle.return_value = ({'result': '<bpmn>test</bpmn>'}, 200)
-        
-        response = client.post('/generate_bpmn', json={
-            'text': 'test process',
-            'api_key': 'test_key'
-        })
-        
+        mock_handle.return_value = ({"result": "<bpmn>test</bpmn>"}, 200)
+
+        response = client.post(
+            "/generate_bpmn", json={"text": "test process", "api_key": "test_key"}
+        )
+
         assert response.status_code == 200
         mock_handle.assert_called_once()
-    
-    @patch('app.api.routes.HandleCall.handle')
+
+    @patch("app.api.routes.HandleCall.handle")
     def test_generate_bpmn_uppercase_success(self, mock_handle, client):
-        mock_handle.return_value = ({'result': '<bpmn>test</bpmn>'}, 200)
-        
-        response = client.post('/generate_BPMN', json={
-            'text': 'test process',
-            'api_key': 'test_key'
-        })
-        
+        mock_handle.return_value = ({"result": "<bpmn>test</bpmn>"}, 200)
+
+        response = client.post(
+            "/generate_BPMN", json={"text": "test process", "api_key": "test_key"}
+        )
+
         assert response.status_code == 200
         mock_handle.assert_called_once()
-    
-    @patch('app.api.routes.HandleCall.handle')
+
+    @patch("app.api.routes.HandleCall.handle")
     def test_generate_bpmn_with_tuple_response(self, mock_handle, client):
         # HandleCall can return (response, status_code) tuple
-        mock_handle.return_value = ({'result': '<bpmn>test</bpmn>'}, 201)
-        
-        response = client.post('/generate_bpmn', json={
-            'text': 'test process',
-            'api_key': 'test_key'
-        })
-        
+        mock_handle.return_value = ({"result": "<bpmn>test</bpmn>"}, 201)
+
+        response = client.post(
+            "/generate_bpmn", json={"text": "test process", "api_key": "test_key"}
+        )
+
         assert response.status_code == 201
-    
-    @patch('app.api.routes.HandleCall.handle')
+
+    @patch("app.api.routes.HandleCall.handle")
     def test_generate_bpmn_exception(self, mock_handle, client):
         mock_handle.side_effect = Exception("Processing error")
-        
-        response = client.post('/generate_bpmn', json={
-            'text': 'test process',
-            'api_key': 'test_key'
-        })
-        
+
+        response = client.post(
+            "/generate_bpmn", json={"text": "test process", "api_key": "test_key"}
+        )
+
         assert response.status_code == 500
-        assert 'error' in response.json
+        assert "error" in response.json
 
 
 class TestGeneratePNML:
     """Tests for /generate_pnml and /generate_PNML endpoints"""
-    
-    @patch('app.api.routes.HandleCall.handle')
+
+    @patch("app.api.routes.HandleCall.handle")
     def test_generate_pnml_lowercase_success(self, mock_handle, client):
-        mock_handle.return_value = ({'result': '<pnml>test</pnml>'}, 200)
-        
-        response = client.post('/generate_pnml', json={
-            'text': 'test process',
-            'api_key': 'test_key'
-        })
-        
+        mock_handle.return_value = ({"result": "<pnml>test</pnml>"}, 200)
+
+        response = client.post(
+            "/generate_pnml", json={"text": "test process", "api_key": "test_key"}
+        )
+
         assert response.status_code == 200
         mock_handle.assert_called_once()
         # Verify correct direction parameter
         call_args = mock_handle.call_args
-        assert call_args[0][1]['direction'] == 'bpmntopnml'
-    
-    @patch('app.api.routes.HandleCall.handle')
+        assert call_args[0][1]["direction"] == "bpmntopnml"
+
+    @patch("app.api.routes.HandleCall.handle")
     def test_generate_pnml_uppercase_success(self, mock_handle, client):
-        mock_handle.return_value = ({'result': '<pnml>test</pnml>'}, 200)
-        
-        response = client.post('/generate_PNML', json={
-            'text': 'test process',
-            'api_key': 'test_key'
-        })
-        
+        mock_handle.return_value = ({"result": "<pnml>test</pnml>"}, 200)
+
+        response = client.post(
+            "/generate_PNML", json={"text": "test process", "api_key": "test_key"}
+        )
+
         assert response.status_code == 200
-    
-    @patch('app.api.routes.HandleCall.handle')
+
+    @patch("app.api.routes.HandleCall.handle")
     def test_generate_pnml_with_tuple_response(self, mock_handle, client):
-        mock_handle.return_value = ({'result': '<pnml>test</pnml>'}, 201)
-        
-        response = client.post('/generate_pnml', json={
-            'text': 'test process',
-            'api_key': 'test_key'
-        })
-        
+        mock_handle.return_value = ({"result": "<pnml>test</pnml>"}, 201)
+
+        response = client.post(
+            "/generate_pnml", json={"text": "test process", "api_key": "test_key"}
+        )
+
         assert response.status_code == 201
-    
-    @patch('app.api.routes.HandleCall.handle')
+
+    @patch("app.api.routes.HandleCall.handle")
     def test_generate_pnml_exception(self, mock_handle, client):
         mock_handle.side_effect = ValueError("Invalid data")
-        
-        response = client.post('/generate_pnml', json={
-            'text': 'test process',
-            'api_key': 'test_key'
-        })
-        
+
+        response = client.post(
+            "/generate_pnml", json={"text": "test process", "api_key": "test_key"}
+        )
+
         assert response.status_code == 500
-        assert 'error' in response.json
+        assert "error" in response.json
 
 
 class TestEchoEndpoint:
     """Tests for /_/_/echo endpoint"""
-    
+
     def test_echo_success(self, client):
-        response = client.get('/_/_/echo')
+        response = client.get("/_/_/echo")
         assert response.status_code == 200
-        assert response.json == {'success': True}
-    
-    @patch('app.api.routes.REQUEST_COUNT')
-    @patch('app.api.routes.REQUEST_LATENCY')
+        assert response.json == {"success": True}
+
+    @patch("app.api.routes.REQUEST_COUNT")
+    @patch("app.api.routes.REQUEST_LATENCY")
     def test_echo_increments_metrics(self, mock_latency, mock_counter, client):
-        response = client.get('/_/_/echo')
+        response = client.get("/_/_/echo")
         assert response.status_code == 200
         # Verify metrics were updated
         mock_counter.labels.assert_called()

--- a/tests/test_xmlparser.py
+++ b/tests/test_xmlparser.py
@@ -1,23 +1,35 @@
 import pytest
 from app.backend.xml_parser import json_to_bpmn
 
+
 @pytest.fixture
 def example_data():
     return {
-      "events": [
-        {"id": "startEvent1", "type": "Start", "name": "Process Start"},
-        {"id": "endEvent1", "type": "End", "name": "Process End"}
-      ],
-      "tasks": [
-        {"id": "task1", "name": "Check for Known Outages", "type": "ServiceTask"}
-      ],
-      "gateways": [],
-      "flows": [
-        {"id": "flow1", "source": "startEvent1", "target": "task1", "type": "SequenceFlow"},
-        {"id": "flow2", "source": "task1", "target": "endEvent1", "type": "SequenceFlow"}
-      ],
-      "participants": []
+        "events": [
+            {"id": "startEvent1", "type": "Start", "name": "Process Start"},
+            {"id": "endEvent1", "type": "End", "name": "Process End"},
+        ],
+        "tasks": [
+            {"id": "task1", "name": "Check for Known Outages", "type": "ServiceTask"}
+        ],
+        "gateways": [],
+        "flows": [
+            {
+                "id": "flow1",
+                "source": "startEvent1",
+                "target": "task1",
+                "type": "SequenceFlow",
+            },
+            {
+                "id": "flow2",
+                "source": "task1",
+                "target": "endEvent1",
+                "type": "SequenceFlow",
+            },
+        ],
+        "participants": [],
     }
+
 
 def test_json_to_bpmn_generates_xml(example_data):
     result = json_to_bpmn(example_data)
@@ -25,7 +37,7 @@ def test_json_to_bpmn_generates_xml(example_data):
     # Prüfen, ob der Output ein gültiger XML-String ist
     assert isinstance(result, str)
     assert "<?xml" in result
-    assert "<definitions" in result   # nicht mehr '<bpmn:definitions'
+    assert "<definitions" in result  # nicht mehr '<bpmn:definitions'
     assert "startEvent1" in result
     assert "task1" in result
     assert "endEvent1" in result
@@ -36,23 +48,36 @@ def test_json_to_bpmn_with_gateways():
     data = {
         "events": [
             {"id": "start1", "type": "Start", "name": "Start"},
-            {"id": "end1", "type": "End", "name": "End"}
+            {"id": "end1", "type": "End", "name": "End"},
         ],
-        "tasks": [
-            {"id": "task1", "name": "Task 1", "type": "UserTask"}
-        ],
+        "tasks": [{"id": "task1", "name": "Task 1", "type": "UserTask"}],
         "gateways": [
             {"id": "gateway1", "type": "ExclusiveGateway", "name": "Decision"}
         ],
         "flows": [
-            {"id": "flow1", "source": "start1", "target": "task1", "type": "SequenceFlow"},
-            {"id": "flow2", "source": "task1", "target": "gateway1", "type": "SequenceFlow"},
-            {"id": "flow3", "source": "gateway1", "target": "end1", "type": "SequenceFlow"}
-        ]
+            {
+                "id": "flow1",
+                "source": "start1",
+                "target": "task1",
+                "type": "SequenceFlow",
+            },
+            {
+                "id": "flow2",
+                "source": "task1",
+                "target": "gateway1",
+                "type": "SequenceFlow",
+            },
+            {
+                "id": "flow3",
+                "source": "gateway1",
+                "target": "end1",
+                "type": "SequenceFlow",
+            },
+        ],
     }
-    
+
     result = json_to_bpmn(data)
-    
+
     assert "gateway1" in result
     assert "ExclusiveGateway" in result or "exclusiveGateway" in result
 
@@ -62,24 +87,44 @@ def test_json_to_bpmn_with_multiple_tasks():
     data = {
         "events": [
             {"id": "start1", "type": "Start", "name": "Start"},
-            {"id": "end1", "type": "End", "name": "End"}
+            {"id": "end1", "type": "End", "name": "End"},
         ],
         "tasks": [
             {"id": "task1", "name": "Task 1", "type": "ServiceTask"},
             {"id": "task2", "name": "Task 2", "type": "UserTask"},
-            {"id": "task3", "name": "Task 3", "type": "ManualTask"}
+            {"id": "task3", "name": "Task 3", "type": "ManualTask"},
         ],
         "gateways": [],
         "flows": [
-            {"id": "flow1", "source": "start1", "target": "task1", "type": "SequenceFlow"},
-            {"id": "flow2", "source": "task1", "target": "task2", "type": "SequenceFlow"},
-            {"id": "flow3", "source": "task2", "target": "task3", "type": "SequenceFlow"},
-            {"id": "flow4", "source": "task3", "target": "end1", "type": "SequenceFlow"}
-        ]
+            {
+                "id": "flow1",
+                "source": "start1",
+                "target": "task1",
+                "type": "SequenceFlow",
+            },
+            {
+                "id": "flow2",
+                "source": "task1",
+                "target": "task2",
+                "type": "SequenceFlow",
+            },
+            {
+                "id": "flow3",
+                "source": "task2",
+                "target": "task3",
+                "type": "SequenceFlow",
+            },
+            {
+                "id": "flow4",
+                "source": "task3",
+                "target": "end1",
+                "type": "SequenceFlow",
+            },
+        ],
     }
-    
+
     result = json_to_bpmn(data)
-    
+
     assert "task1" in result
     assert "task2" in result
     assert "task3" in result
@@ -93,23 +138,34 @@ def test_json_to_bpmn_with_parallel_gateway():
     data = {
         "events": [
             {"id": "start1", "type": "Start", "name": "Start"},
-            {"id": "end1", "type": "End", "name": "End"}
+            {"id": "end1", "type": "End", "name": "End"},
         ],
-        "tasks": [
-            {"id": "task1", "name": "Task 1", "type": "UserTask"}
-        ],
-        "gateways": [
-            {"id": "gateway1", "type": "ParallelGateway", "name": "Split"}
-        ],
+        "tasks": [{"id": "task1", "name": "Task 1", "type": "UserTask"}],
+        "gateways": [{"id": "gateway1", "type": "ParallelGateway", "name": "Split"}],
         "flows": [
-            {"id": "flow1", "source": "start1", "target": "gateway1", "type": "SequenceFlow"},
-            {"id": "flow2", "source": "gateway1", "target": "task1", "type": "SequenceFlow"},
-            {"id": "flow3", "source": "task1", "target": "end1", "type": "SequenceFlow"}
-        ]
+            {
+                "id": "flow1",
+                "source": "start1",
+                "target": "gateway1",
+                "type": "SequenceFlow",
+            },
+            {
+                "id": "flow2",
+                "source": "gateway1",
+                "target": "task1",
+                "type": "SequenceFlow",
+            },
+            {
+                "id": "flow3",
+                "source": "task1",
+                "target": "end1",
+                "type": "SequenceFlow",
+            },
+        ],
     }
-    
+
     result = json_to_bpmn(data)
-    
+
     assert "gateway1" in result
     assert "ParallelGateway" in result or "parallelGateway" in result
 
@@ -119,17 +175,22 @@ def test_json_to_bpmn_empty_arrays():
     data = {
         "events": [
             {"id": "start1", "type": "Start", "name": ""},
-            {"id": "end1", "type": "End", "name": ""}
+            {"id": "end1", "type": "End", "name": ""},
         ],
         "tasks": [],
         "gateways": [],
         "flows": [
-            {"id": "flow1", "source": "start1", "target": "end1", "type": "SequenceFlow"}
-        ]
+            {
+                "id": "flow1",
+                "source": "start1",
+                "target": "end1",
+                "type": "SequenceFlow",
+            }
+        ],
     }
-    
+
     result = json_to_bpmn(data)
-    
+
     assert isinstance(result, str)
     assert "<?xml" in result
     assert "start1" in result


### PR DESCRIPTION
## Description

This PR applies the configured `ruff-format` hook across the repository.

The change is formatting-only and does not intend to modify behavior. It separates mechanical formatting changes from future code changes so later diffs remain easier to review.

Local test result:
- `pytest`: 82 passed
- 2 pre-existing failures remain in `test_routes.py` related to the metrics context

## Checklist

- [x] Code has been tested locally
- [ ] All existing tests pass
- [ ] Changes are documented
- [x] PR adheres to the [contributing guidelines](.github/contributing.md)
- [ ] Reviewers have been assigned

## Additional Notes

This PR only contains formatting changes produced by the configured formatter.